### PR TITLE
FamilySearch Json - Fix no spouse => null

### DIFF
--- a/collections/familysearchjson.js
+++ b/collections/familysearchjson.js
@@ -318,7 +318,7 @@ function parseFamilySearchJSON(htmlstring, familymembers, relation) {
                         spouse = jsonrel[x]["parent1"]["id"];
                         image = jsonrel[x]["parent1"]["portraitUrl"] || "";
                     }
-                    if (spouse !== "") {
+                    if (spouse) {
                         var data = parseFSJSONUnion(jsonrel[x]["event"]);
                         var valid = processFamilySearchJSON(spouse, "spouse", famid, image, data);
                         if (valid) {


### PR DESCRIPTION
`Spouse = null`
throws:
```
popup.html:1 Error handling response: SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at chrome-extension://ofikakkdpjlipbnhbfloclbkcabdhjah/collections/familysearchjson.js:355:49
```