### PR TITLE
Fix regression from #191: "null" is not a valid postMessage targetOrigin

### DIFF
--- a/offscreen.js
+++ b/offscreen.js
@@ -20,7 +20,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             listenerAdded = true;
         }
         pendingResponse = sendResponse;
-        iframe.contentWindow.postMessage(request.data, "null");
+        // "*" is the only targetOrigin value that can actually deliver to
+        // an opaque-origin destination like this sandboxed iframe - "null"
+        // (from #191) is not a valid target and throws synchronously
+        // ("Invalid target origin 'null'"), confirmed empirically; "null"
+        // is only ever what a *receiving* handler sees as event.origin for
+        // a message sent from an opaque origin, not something a sender can
+        // target. The event.source check in handleMessage() above (also
+        // from #191) is the actually-effective fix for the reported
+        // vulnerability - it validates incoming messages regardless of
+        // what targetOrigin was used to send this one.
+        iframe.contentWindow.postMessage(request.data, "*");
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary

#191 (merged as part of 4.15.0.0) changed `offscreen.js`'s `postMessage` call from `postMessage(request.data, "*")` to `postMessage(request.data, "null")`, intending to restrict delivery to the sandboxed iframe's opaque origin. Verified empirically (isolated test page, same opaque-origin iframe setup) that this throws synchronously instead:

```
Failed to execute 'postMessage' on 'Window': Invalid target origin 'null' in a call to 'postMessage'.
```

`"null"` is what a *receiving* handler sees as `event.origin` for a message sent from an opaque-origin sender - it was never valid to pass as the *target* origin when sending *to* one. Tested several other candidate strings (`""`, `"/"`, `"about:blank"`) - none correctly and exclusively target an opaque-origin destination. `"*"` is the only value that actually delivers.

## Impact

This broke `evalObject()`/`evalInSandboxIframe()` in Chrome on every call. The only current caller is `collections/ancestrynew.js`'s legacy `PersonCard` extraction, which already has a `try/catch` + `|| {}` fallback around this call, so the practical effect was silently degraded (not crashed or hung) data on legacy Ancestry pages, not a hang or a visible error.

## Fix

Revert just the `targetOrigin` argument back to `"*"`. Keeps the other half of #191 - the `event.source` check in `handleMessage()` - which is the part that's actually effective against the reported vulnerability (unvalidated incoming messages), and doesn't depend on what `targetOrigin` was used to send a given message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)